### PR TITLE
Fixing appendonly always 'yes' in redis-cluster chart

### DIFF
--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -414,7 +414,7 @@ redis_configure_default() {
         redis_conf_set bind 0.0.0.0 # Allow remote connections
         # Enable AOF https://redis.io/topics/persistence#append-only-file
         # Leave default fsync (every second)
-        redis_conf_set appendonly yes
+        # redis_conf_set appendonly yes
         # Disable RDB persistence, AOF persistence already enabled.
         # Ref: https://redis.io/topics/persistence#interactions-between-aof-and-rdb-persistence
         redis_conf_set save ""


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

appendonly should come from the customized setting, specifically redis-default.conf where appendonly is 'no'.


**Benefits**

'appendonly' configuration can be set to 'yes' or 'no' from the chart values file

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

https://github.com/bitnami/charts/issues/2505

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
