### PR TITLE
Always set announce-ip

### DIFF
--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -90,6 +90,10 @@ redis_cluster_override_conf() {
     if ! (is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS" || is_boolean_yes "$REDIS_CLUSTER_CREATOR"); then
         redis_conf_set cluster-announce-ip "$REDIS_CLUSTER_ANNOUNCE_IP"
     fi
+    if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
+        # Always set the announce-ip to avoid issues when using proxies and traffic restrictions.
+        redis_conf_set cluster-announce-ip "$(hostname -i)"
+    fi
     if is_boolean_yes "$REDIS_TLS_ENABLED"; then
         redis_conf_set tls-cluster yes
         redis_conf_set tls-replication yes
@@ -207,7 +211,7 @@ redis_cluster_update_ips() {
             if [[ ${host_2_ip_array[$node]+true} ]]; then
                 echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
                 nodesFile=$(sed "s/${host_2_ip_array[$node]}/$newIP/g" "${REDIS_DATA_DIR}/nodes.conf")
-                echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
+                echo "$nodesFile" > "${REDIS_DATA_DIR}/nodes.conf"
             fi
             host_2_ip_array["$node"]="$newIP"
         done

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -92,7 +92,7 @@ redis_cluster_override_conf() {
     fi
     if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
         # Always set the announce-ip to avoid issues when using proxies and traffic restrictions.
-        redis_conf_set cluster-announce-ip "$(hostname -i)"
+        redis_conf_set cluster-announce-ip "$(get_machine_ip)"
     fi
     if is_boolean_yes "$REDIS_TLS_ENABLED"; then
         redis_conf_set tls-cluster yes


### PR DESCRIPTION
Signed-off-by: Miguel A. Cabrera Minagorri <macabrera@bitnami.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

By always setting the announce IP we solve some issues when using Istio. These issues were caused by announcing `127.0.0.1` in the first node that joined the cluster making it impossible to be reached.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
