### PR TITLE
Fixed carriage return, new line or tab in redis_conf_set()

### DIFF
--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -49,6 +49,7 @@ redis_conf_set() {
     value="${value//\\/\\\\}"
     value="${value//&/\\&}"
     value="${value//\?/\\?}"
+    value="${value//[$'\t\n\r']}"
     [[ "$value" = "" ]] && value="\"$value\""
 
     replace_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^#*\s*${key} .*" "${key} ${value}" false

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -49,6 +49,7 @@ redis_conf_set() {
     value="${value//\\/\\\\}"
     value="${value//&/\\&}"
     value="${value//\?/\\?}"
+    value="${value//[$'\t\n\r']}"
     [[ "$value" = "" ]] && value="\"$value\""
 
     replace_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^#*\s*${key} .*" "${key} ${value}" false

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/libredis.sh
@@ -49,6 +49,7 @@ redis_conf_set() {
     value="${value//\\/\\\\}"
     value="${value//&/\\&}"
     value="${value//\?/\\?}"
+    value="${value//[$'\t\n\r']}"
     [[ "$value" = "" ]] && value="\"$value\""
 
     replace_in_file "${REDIS_BASE_DIR}/etc/redis.conf" "^#*\s*${key} .*" "${key} ${value}" false


### PR DESCRIPTION
**Description of the change**

This change adds sanitize inputs.

**Benefits**

Added tab, new line and carriage return clearing to set config parameter value.

**Possible drawbacks**

No limitations

**Applicable issues**

I had an issue with "sed"
from log file:
***
+ replace_in_file /opt/bitnami/redis/etc/redis.conf '^#*\s*requirepass .*' 'requirepass redisadmin
' false
+ local filename=/opt/bitnami/redis/etc/redis.conf
+ local 'match_regex=^#*\s*requirepass .*'
+ local 'substitute_regex=requirepass redisadmin
'
+ local posix_regex=false
+ local result
+ del=$'\001'
+ [[ false = true ]]
++ sed 's^#*\s*requirepass .*requirepass redisadmin
g' /opt/bitnami/redis/etc/redis.conf
sed: -e expression #1, char 45: unterminated `s' command
+ result=
redis_stop
***

**Additional information**

I used
https://stackoverflow.com/a/19347380
