### PR TITLE
Change init cluster logic

### DIFF
--- a/5.0/debian-10/docker-compose.yml
+++ b/5.0/debian-10/docker-compose.yml
@@ -44,20 +44,14 @@ services:
     image: docker.io/bitnami/redis-cluster:5.0
     volumes:
       - redis-cluster_data-5:/bitnami/redis/data
-    environment:
-      - 'REDIS_PASSWORD=bitnami'
-      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
-
-  redis-cluster-init:
-    image: docker.io/bitnami/redis-cluster:5.0
     depends_on:
       - redis-node-0
       - redis-node-1
       - redis-node-2
       - redis-node-3
       - redis-node-4
-      - redis-node-5
     environment:
+      - 'REDIS_PASSWORD=bitnami'
       - 'REDISCLI_AUTH=bitnami'
       - 'REDIS_CLUSTER_REPLICAS=1'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'

--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -182,7 +182,7 @@ redis_cluster_check() {
 #   None
 #########################
 redis_cluster_update_ips() {
-    IFS=' ' read -ra nodes <<<"$REDIS_NODES"
+    read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
 
     declare -A host_2_ip_array # Array to map hosts and IPs
     # Update the IPs when a number of nodes > quorum change their IPs

--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -45,15 +45,11 @@ redis_cluster_validate() {
     if is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
         empty_password_enabled_warn
     else
-        if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-            [[ -z "$REDIS_PASSWORD" ]] && empty_password_error REDIS_PASSWORD
-        fi
+        [[ -z "$REDIS_PASSWORD" ]] && empty_password_error REDIS_PASSWORD
     fi
 
     if ! is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
-        if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-            [[ -z "$REDIS_CLUSTER_ANNOUNCE_IP" ]] && print_validation_error "To provide external access you need to provide the REDIS_CLUSTER_ANNOUNCE_IP env var"
-        fi
+        [[ -z "$REDIS_CLUSTER_ANNOUNCE_IP" ]] && print_validation_error "To provide external access you need to provide the REDIS_CLUSTER_ANNOUNCE_IP env var"
     fi
 
     [[ -z "$REDIS_NODES" ]] && print_validation_error "REDIS_NODES is required"
@@ -63,7 +59,7 @@ redis_cluster_validate() {
     fi
 
     if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-        [[ -z "$REDIS_CLUSTER_REPLICAS" ]] && print_validation_error "To create the cluster you need to provide the number of replicas"
+        [[ -z "$REDIS_CLUSTER_REPLICAS" ]] && print_validation_error "To create the cluster you need to provide the number of replicas to the cluster creator"
     fi
 
     if ((REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP < 0)); then
@@ -84,7 +80,7 @@ redis_cluster_validate() {
 #########################
 redis_cluster_override_conf() {
     # Redis configuration to override
-    if ! (is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS" || is_boolean_yes "$REDIS_CLUSTER_CREATOR"); then
+    if ! is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
         redis_conf_set cluster-announce-ip "$REDIS_CLUSTER_ANNOUNCE_IP"
     fi
     if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then

--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -31,13 +31,7 @@ fi
 
 ARGS+=("$@")
 
-if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-    if am_i_root; then
-        exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
-    else
-        exec redis-server "${ARGS[@]}"
-    fi
-else
+if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
     # Start Redis in background
     if am_i_root; then
         gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &
@@ -48,4 +42,10 @@ else
     redis_cluster_create "${nodes[@]}"
     # Bring redis process to foreground
     fg
+else
+    if am_i_root; then
+        exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
+    else
+        exec redis-server "${ARGS[@]}"
+    fi
 fi

--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -7,6 +7,9 @@ set -o nounset
 set -o pipefail
 # set -o xtrace # Uncomment this line for debugging purpose
 
+# We need  to enable job control
+set -m
+
 # Load Redis environment variables
 . /opt/bitnami/scripts/redis-cluster-env.sh
 
@@ -16,24 +19,33 @@ set -o pipefail
 
 IFS=' ' read -ra nodes <<< "$REDIS_NODES"
 
+ARGS=("--port" "$REDIS_PORT_NUMBER")
+ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")
+
+if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+    ARGS+=("--requirepass" "$REDIS_PASSWORD")
+    ARGS+=("--masterauth" "$REDIS_PASSWORD")
+else
+    ARGS+=("--protected-mode" "no")
+fi
+
+ARGS+=("$@")
+
 if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-    ARGS=("--port" "$REDIS_PORT_NUMBER")
-    ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")
-
-    if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
-        ARGS+=("--requirepass" "$REDIS_PASSWORD")
-        ARGS+=("--masterauth" "$REDIS_PASSWORD")
-    else
-        ARGS+=("--protected-mode" "no")
-    fi
-
-    ARGS+=("$@")
-
     if am_i_root; then
         exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
     else
         exec redis-server "${ARGS[@]}"
     fi
 else
+    # Start Redis in background
+    if am_i_root; then
+        gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &
+    else
+        redis-server "${ARGS[@]}" &
+    fi
+    # Create the cluster
     redis_cluster_create "${nodes[@]}"
+    # Bring redis process to foreground
+    fg
 fi

--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -7,7 +7,8 @@ set -o nounset
 set -o pipefail
 # set -o xtrace # Uncomment this line for debugging purpose
 
-# We need  to enable job control
+# Enable job control
+# ref https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin
 set -m
 
 # Load Redis environment variables
@@ -17,7 +18,7 @@ set -m
 . /opt/bitnami/scripts/libos.sh
 . /opt/bitnami/scripts/librediscluster.sh
 
-IFS=' ' read -ra nodes <<< "$REDIS_NODES"
+read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
 
 ARGS=("--port" "$REDIS_PORT_NUMBER")
 ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")

--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/setup.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/setup.sh
@@ -24,6 +24,6 @@ am_i_root && ensure_user_exists "$REDIS_DAEMON_USER" --group "$REDIS_DAEMON_GROU
 # Ensure Redis is initialized
 redis_cluster_initialize
 
-if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR" && is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
+if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
     redis_cluster_update_ips
 fi

--- a/6.0/debian-10/docker-compose.yml
+++ b/6.0/debian-10/docker-compose.yml
@@ -44,20 +44,14 @@ services:
     image: docker.io/bitnami/redis-cluster:6.0
     volumes:
       - redis-cluster_data-5:/bitnami/redis/data
-    environment:
-      - 'REDIS_PASSWORD=bitnami'
-      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
-
-  redis-cluster-init:
-    image: docker.io/bitnami/redis-cluster:6.0
     depends_on:
       - redis-node-0
       - redis-node-1
       - redis-node-2
       - redis-node-3
       - redis-node-4
-      - redis-node-5
     environment:
+      - 'REDIS_PASSWORD=bitnami'
       - 'REDISCLI_AUTH=bitnami'
       - 'REDIS_CLUSTER_REPLICAS=1'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -182,7 +182,7 @@ redis_cluster_check() {
 #   None
 #########################
 redis_cluster_update_ips() {
-    IFS=' ' read -ra nodes <<<"$REDIS_NODES"
+    read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
 
     declare -A host_2_ip_array # Array to map hosts and IPs
     # Update the IPs when a number of nodes > quorum change their IPs

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -45,15 +45,11 @@ redis_cluster_validate() {
     if is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
         empty_password_enabled_warn
     else
-        if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-            [[ -z "$REDIS_PASSWORD" ]] && empty_password_error REDIS_PASSWORD
-        fi
+        [[ -z "$REDIS_PASSWORD" ]] && empty_password_error REDIS_PASSWORD
     fi
 
     if ! is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
-        if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-            [[ -z "$REDIS_CLUSTER_ANNOUNCE_IP" ]] && print_validation_error "To provide external access you need to provide the REDIS_CLUSTER_ANNOUNCE_IP env var"
-        fi
+        [[ -z "$REDIS_CLUSTER_ANNOUNCE_IP" ]] && print_validation_error "To provide external access you need to provide the REDIS_CLUSTER_ANNOUNCE_IP env var"
     fi
 
     [[ -z "$REDIS_NODES" ]] && print_validation_error "REDIS_NODES is required"
@@ -63,7 +59,7 @@ redis_cluster_validate() {
     fi
 
     if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-        [[ -z "$REDIS_CLUSTER_REPLICAS" ]] && print_validation_error "To create the cluster you need to provide the number of replicas"
+        [[ -z "$REDIS_CLUSTER_REPLICAS" ]] && print_validation_error "To create the cluster you need to provide the number of replicas to the cluster creator"
     fi
 
     if ((REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP < 0)); then
@@ -84,7 +80,7 @@ redis_cluster_validate() {
 #########################
 redis_cluster_override_conf() {
     # Redis configuration to override
-    if ! (is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS" || is_boolean_yes "$REDIS_CLUSTER_CREATOR"); then
+    if ! is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
         redis_conf_set cluster-announce-ip "$REDIS_CLUSTER_ANNOUNCE_IP"
     fi
     if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -31,13 +31,7 @@ fi
 
 ARGS+=("$@")
 
-if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-    if am_i_root; then
-        exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
-    else
-        exec redis-server "${ARGS[@]}"
-    fi
-else
+if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
     # Start Redis in background
     if am_i_root; then
         gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &
@@ -48,4 +42,10 @@ else
     redis_cluster_create "${nodes[@]}"
     # Bring redis process to foreground
     fg
+else
+    if am_i_root; then
+        exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
+    else
+        exec redis-server "${ARGS[@]}"
+    fi
 fi

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -7,6 +7,9 @@ set -o nounset
 set -o pipefail
 # set -o xtrace # Uncomment this line for debugging purpose
 
+# We need  to enable job control
+set -m
+
 # Load Redis environment variables
 . /opt/bitnami/scripts/redis-cluster-env.sh
 
@@ -16,24 +19,33 @@ set -o pipefail
 
 IFS=' ' read -ra nodes <<< "$REDIS_NODES"
 
+ARGS=("--port" "$REDIS_PORT_NUMBER")
+ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")
+
+if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+    ARGS+=("--requirepass" "$REDIS_PASSWORD")
+    ARGS+=("--masterauth" "$REDIS_PASSWORD")
+else
+    ARGS+=("--protected-mode" "no")
+fi
+
+ARGS+=("$@")
+
 if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-    ARGS=("--port" "$REDIS_PORT_NUMBER")
-    ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")
-
-    if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
-        ARGS+=("--requirepass" "$REDIS_PASSWORD")
-        ARGS+=("--masterauth" "$REDIS_PASSWORD")
-    else
-        ARGS+=("--protected-mode" "no")
-    fi
-
-    ARGS+=("$@")
-
     if am_i_root; then
         exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
     else
         exec redis-server "${ARGS[@]}"
     fi
 else
+    # Start Redis in background
+    if am_i_root; then
+        gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &
+    else
+        redis-server "${ARGS[@]}" &
+    fi
+    # Create the cluster
     redis_cluster_create "${nodes[@]}"
+    # Bring redis process to foreground
+    fg
 fi

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -7,7 +7,8 @@ set -o nounset
 set -o pipefail
 # set -o xtrace # Uncomment this line for debugging purpose
 
-# We need  to enable job control
+# Enable job control
+# ref https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin
 set -m
 
 # Load Redis environment variables
@@ -17,7 +18,7 @@ set -m
 . /opt/bitnami/scripts/libos.sh
 . /opt/bitnami/scripts/librediscluster.sh
 
-IFS=' ' read -ra nodes <<< "$REDIS_NODES"
+read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
 
 ARGS=("--port" "$REDIS_PORT_NUMBER")
 ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/setup.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/setup.sh
@@ -24,6 +24,6 @@ am_i_root && ensure_user_exists "$REDIS_DAEMON_USER" --group "$REDIS_DAEMON_GROU
 # Ensure Redis is initialized
 redis_cluster_initialize
 
-if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR" && is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
+if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
     redis_cluster_update_ips
 fi

--- a/6.2/debian-10/docker-compose.yml
+++ b/6.2/debian-10/docker-compose.yml
@@ -44,20 +44,14 @@ services:
     image: docker.io/bitnami/redis-cluster:6.2
     volumes:
       - redis-cluster_data-5:/bitnami/redis/data
-    environment:
-      - 'REDIS_PASSWORD=bitnami'
-      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
-
-  redis-cluster-init:
-    image: docker.io/bitnami/redis-cluster:6.2
     depends_on:
       - redis-node-0
       - redis-node-1
       - redis-node-2
       - redis-node-3
       - redis-node-4
-      - redis-node-5
     environment:
+      - 'REDIS_PASSWORD=bitnami'
       - 'REDISCLI_AUTH=bitnami'
       - 'REDIS_CLUSTER_REPLICAS=1'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -182,7 +182,7 @@ redis_cluster_check() {
 #   None
 #########################
 redis_cluster_update_ips() {
-    IFS=' ' read -ra nodes <<<"$REDIS_NODES"
+    read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
 
     declare -A host_2_ip_array # Array to map hosts and IPs
     # Update the IPs when a number of nodes > quorum change their IPs

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -45,15 +45,11 @@ redis_cluster_validate() {
     if is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
         empty_password_enabled_warn
     else
-        if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-            [[ -z "$REDIS_PASSWORD" ]] && empty_password_error REDIS_PASSWORD
-        fi
+        [[ -z "$REDIS_PASSWORD" ]] && empty_password_error REDIS_PASSWORD
     fi
 
     if ! is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
-        if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-            [[ -z "$REDIS_CLUSTER_ANNOUNCE_IP" ]] && print_validation_error "To provide external access you need to provide the REDIS_CLUSTER_ANNOUNCE_IP env var"
-        fi
+        [[ -z "$REDIS_CLUSTER_ANNOUNCE_IP" ]] && print_validation_error "To provide external access you need to provide the REDIS_CLUSTER_ANNOUNCE_IP env var"
     fi
 
     [[ -z "$REDIS_NODES" ]] && print_validation_error "REDIS_NODES is required"
@@ -63,7 +59,7 @@ redis_cluster_validate() {
     fi
 
     if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-        [[ -z "$REDIS_CLUSTER_REPLICAS" ]] && print_validation_error "To create the cluster you need to provide the number of replicas"
+        [[ -z "$REDIS_CLUSTER_REPLICAS" ]] && print_validation_error "To create the cluster you need to provide the number of replicas to the cluster creator"
     fi
 
     if ((REDIS_CLUSTER_SLEEP_BEFORE_DNS_LOOKUP < 0)); then
@@ -84,7 +80,7 @@ redis_cluster_validate() {
 #########################
 redis_cluster_override_conf() {
     # Redis configuration to override
-    if ! (is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS" || is_boolean_yes "$REDIS_CLUSTER_CREATOR"); then
+    if ! is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
         redis_conf_set cluster-announce-ip "$REDIS_CLUSTER_ANNOUNCE_IP"
     fi
     if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -31,13 +31,7 @@ fi
 
 ARGS+=("$@")
 
-if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-    if am_i_root; then
-        exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
-    else
-        exec redis-server "${ARGS[@]}"
-    fi
-else
+if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
     # Start Redis in background
     if am_i_root; then
         gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &
@@ -48,4 +42,10 @@ else
     redis_cluster_create "${nodes[@]}"
     # Bring redis process to foreground
     fg
+else
+    if am_i_root; then
+        exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
+    else
+        exec redis-server "${ARGS[@]}"
+    fi
 fi

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -7,6 +7,9 @@ set -o nounset
 set -o pipefail
 # set -o xtrace # Uncomment this line for debugging purpose
 
+# We need  to enable job control
+set -m
+
 # Load Redis environment variables
 . /opt/bitnami/scripts/redis-cluster-env.sh
 
@@ -16,24 +19,33 @@ set -o pipefail
 
 IFS=' ' read -ra nodes <<< "$REDIS_NODES"
 
+ARGS=("--port" "$REDIS_PORT_NUMBER")
+ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")
+
+if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
+    ARGS+=("--requirepass" "$REDIS_PASSWORD")
+    ARGS+=("--masterauth" "$REDIS_PASSWORD")
+else
+    ARGS+=("--protected-mode" "no")
+fi
+
+ARGS+=("$@")
+
 if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
-    ARGS=("--port" "$REDIS_PORT_NUMBER")
-    ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")
-
-    if ! is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
-        ARGS+=("--requirepass" "$REDIS_PASSWORD")
-        ARGS+=("--masterauth" "$REDIS_PASSWORD")
-    else
-        ARGS+=("--protected-mode" "no")
-    fi
-
-    ARGS+=("$@")
-
     if am_i_root; then
         exec gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}"
     else
         exec redis-server "${ARGS[@]}"
     fi
 else
+    # Start Redis in background
+    if am_i_root; then
+        gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &
+    else
+        redis-server "${ARGS[@]}" &
+    fi
+    # Create the cluster
     redis_cluster_create "${nodes[@]}"
+    # Bring redis process to foreground
+    fg
 fi

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -7,7 +7,8 @@ set -o nounset
 set -o pipefail
 # set -o xtrace # Uncomment this line for debugging purpose
 
-# We need  to enable job control
+# Enable job control
+# ref https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin
 set -m
 
 # Load Redis environment variables
@@ -17,7 +18,7 @@ set -m
 . /opt/bitnami/scripts/libos.sh
 . /opt/bitnami/scripts/librediscluster.sh
 
-IFS=' ' read -ra nodes <<< "$REDIS_NODES"
+read -ra nodes <<< "$(tr ',;' ' ' <<< "${REDIS_NODES}")"
 
 ARGS=("--port" "$REDIS_PORT_NUMBER")
 ARGS+=("--include" "${REDIS_BASE_DIR}/etc/redis.conf")

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/setup.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/setup.sh
@@ -24,6 +24,6 @@ am_i_root && ensure_user_exists "$REDIS_DAEMON_USER" --group "$REDIS_DAEMON_GROU
 # Ensure Redis is initialized
 redis_cluster_initialize
 
-if ! is_boolean_yes "$REDIS_CLUSTER_CREATOR" && is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
+if is_boolean_yes "$REDIS_CLUSTER_DYNAMIC_IPS"; then
     redis_cluster_update_ips
 fi

--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ Bitnami containers can be used with [Kubeapps](https://kubeapps.com/) for deploy
 
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
-
-* [`6.2`, `6.2-debian-10`, `6.2.2`, `6.2.2-debian-10-r1`, `latest` (6.2/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-redis-cluster/blob/6.2.2-debian-10-r1/6.2/debian-10/Dockerfile)
-* [`6.0`, `6.0-debian-10`, `6.0.12`, `6.0.12-debian-10-r47` (6.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-redis-cluster/blob/6.0.12-debian-10-r47/6.0/debian-10/Dockerfile)
-* [`5.0`, `5.0-debian-10`, `5.0.12`, `5.0.12-debian-10-r47` (5.0/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-redis-cluster/blob/5.0.12-debian-10-r47/5.0/debian-10/Dockerfile)
+{{ range $index, $b := .Branches }}
+* [{{ range $index, $tag := .Tags }}{{ if ne $index 0 }}, {{ end }}`{{ $tag }}`{{ end }} ({{ $b.ReleaseSeries }}/{{ .Distro }}/Dockerfile)](https://github.com/bitnami/bitnami-docker-redis-cluster/blob/{{ .Version }}/{{ .ReleaseSeries }}/{{ .Distro }}/Dockerfile)
+{{- end }}
 
 Subscribe to project updates by watching the [bitnami/redis-cluster GitHub repo](https://github.com/bitnami/bitnami-docker-redis-cluster).
 
@@ -65,7 +64,7 @@ $ docker pull bitnami/redis-cluster:[TAG]
 If you wish, you can also build the image yourself.
 
 ```console
-$ docker build -t bitnami/redis-cluster:latest 'https://github.com/bitnami/bitnami-docker-redis-cluster.git#master:6.2/debian-10'
+{{ range $index, $b := .Branches }}{{- range $index, $tag := .Tags }}{{- if eq $tag "latest" }}$ docker build -t bitnami/redis-cluster:latest 'https://github.com/bitnami/bitnami-docker-redis-cluster.git#master:{{ $b.ReleaseSeries }}/{{ $b.Distro }}'{{- end }}{{- end }}{{- end }}
 ```
 
 # Persisting your application
@@ -146,20 +145,19 @@ services:
 Refer to the [Redis(TM) configuration](http://redis.io/topics/config) manual for the complete list of configuration options.
 
 The following env vars are supported for this container:
-
 | Name                                    | Description                                                                                                                                                                            |
 |-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `REDIS_DISABLE_COMMANDS`                | Disables the specified Redis(TM) commands                                                                                                                                              |
-| `REDIS_PORT_NUMBER`                     | Set the Redis(TM) port. Default=: `6379`                                                                                                                                               |
-| `REDIS_PASSWORD`                        | Set the Redis(TM) password. Default: `bitnami`                                                                                                                                         |
+| `REDIS_DISABLE_COMMANDS`                | Disables the specified Redis(TM) commands                                                                                                                                                  |
+| `REDIS_PORT_NUMBER`                     | Set the Redis(TM) port. Default=: `6379`                                                                                                                                                   |
+| `REDIS_PASSWORD`                        | Set the Redis(TM) password. Default: `bitnami`                                                                                                                                             |
 | `ALLOW_EMPTY_PASSWORD`                  | Enables access without password                                                                                                                                                        |
 | `REDIS_DNS_RETRIES`                     | Number of retries to get the IPs of the provided `REDIS_NODES`. It will wait 5 seconds between retries                                                                                 |
 | `REDISCLI_AUTH`                         | Provide the same value as the configured `REDIS_PASSWORD` for the redis-cli tool to authenticate                                                                                       |
-| `REDIS_CLUSTER_CREATOR`                 | Set to `yes` if the container will be the one on charge of initialize the cluster. This node will not be part of the cluster, it will complete the execution after the initialization. |
+| `REDIS_CLUSTER_CREATOR`                 | Set to `yes` if the container will be the one on charge of initialize the cluster. This node will also be part of the cluster.                                                         |
 | `REDIS_CLUSTER_REPLICAS`                | Number of replicas for every master that the cluster will have.                                                                                                                        |
 | `REDIS_NODES`                           | String delimited by spaces containing the hostnames of all of the nodes that will be part of the cluster                                                                               |
 | `REDIS_CLUSTER_ANNOUNCE_IP`             | IP that the node should announce, used for non dynamic ip environents                                                                                                                  |
-| `REDIS_CLUSTER_DYNAMIC_IPS`             | Set to `no` if your Redis(TM) cluster will be created with statical IPs. Default: `yes`                                                                                                |
+| `REDIS_CLUSTER_DYNAMIC_IPS`             | Set to `no` if your Redis(TM) cluster will be created with statical IPs. Default: `yes`                                                                                                    |
 | `REDIS_TLS_ENABLED`                     | Whether to enable TLS for traffic or not. Defaults to `no`.                                                                                                                            |
 | `REDIS_TLS_PORT`                        | Port used for TLS secure traffic. Defaults to `6379`.                                                                                                                                  |
 | `REDIS_TLS_CERT_FILE`                   | File containing the certificate file for the TSL traffic. No defaults.                                                                                                                 |
@@ -272,6 +270,12 @@ Re-create your container from the new image.
 $ docker run --name redis-cluster bitnami/redis-cluster:latest
 ```
 
+# Upgrading
+
+## To 5.0.12-debian-10-r48 release, 6.2.1-debian-10-r48 release , 6.0.12-debian-10-r48
+
+The cluster initialization logic has changed. Now the container in charge of initialize the cluster will also be part of the cluster. It will initialize Redis in background, create the cluster and then bring back to foreground the Redis process.
+
 # Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an [issue](https://github.com/bitnami/bitnami-docker-redis-cluster/issues), or submit a [pull request](https://github.com/bitnami/bitnami-docker-redis-cluster/pulls) with your contribution.
@@ -288,7 +292,7 @@ If you encountered a problem running this container, you can file an [issue](htt
 
 # License
 
-Copyright (c) 2021 Bitnami
+Copyright (c) {{ .CurrentYear }} Bitnami
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,20 +44,14 @@ services:
     image: docker.io/bitnami/redis-cluster:6.2
     volumes:
       - redis-cluster_data-5:/bitnami/redis/data
-    environment:
-      - 'REDIS_PASSWORD=bitnami'
-      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
-
-  redis-cluster-init:
-    image: docker.io/bitnami/redis-cluster:6.2
     depends_on:
       - redis-node-0
       - redis-node-1
       - redis-node-2
       - redis-node-3
       - redis-node-4
-      - redis-node-5
     environment:
+      - 'REDIS_PASSWORD=bitnami'
       - 'REDISCLI_AUTH=bitnami'
       - 'REDIS_CLUSTER_REPLICAS=1'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This PR changes the cluster initialization logic to avoid the need of an extra container that will die after create the cluster. Now one of the containers that are part of the cluster will initialize it if the proper env vars are provided.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
We can get rid of the hooks in the Helm Chart and we reduce the resources consumption.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
