### PR TITLE
Fix bug for cluster creator container

### DIFF
--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -32,7 +32,7 @@ fi
 
 ARGS+=("$@")
 
-if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
+if is_boolean_yes "$REDIS_CLUSTER_CREATOR" && [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" ]]; then
     # Start Redis in background
     if am_i_root; then
         gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -32,7 +32,7 @@ fi
 
 ARGS+=("$@")
 
-if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
+if is_boolean_yes "$REDIS_CLUSTER_CREATOR" && [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" ]]; then
     # Start Redis in background
     if am_i_root; then
         gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/redis-cluster/run.sh
@@ -32,7 +32,7 @@ fi
 
 ARGS+=("$@")
 
-if is_boolean_yes "$REDIS_CLUSTER_CREATOR"; then
+if is_boolean_yes "$REDIS_CLUSTER_CREATOR" && [[ ! -f "${REDIS_DATA_DIR}/nodes.sh" ]]; then
     # Start Redis in background
     if am_i_root; then
         gosu "$REDIS_DAEMON_USER" redis-server "${ARGS[@]}" &


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

When the cluster creator container tries to initialize the cluster it failed when the cluster was already created. This PR fixes the issue by checking if the cluster has already been initialized
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**
https://github.com/bitnami/bitnami-docker-redis-cluster/issues/26
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
