### PR TITLE
Correct regex logic used to changing IP addresses

### DIFF
--- a/5.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/5.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -203,7 +203,7 @@ redis_cluster_update_ips() {
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
                 echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
-                nodesFile=$(sed "s/${host_2_ip_array[$node]}/$newIP/g" "${REDIS_DATA_DIR}/nodes.conf")
+                nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP:/g" "${REDIS_DATA_DIR}/nodes.conf")
                 echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
             fi
             host_2_ip_array["$node"]="$newIP"

--- a/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/6.0/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -203,7 +203,7 @@ redis_cluster_update_ips() {
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
                 echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
-                nodesFile=$(sed "s/${host_2_ip_array[$node]}/$newIP/g" "${REDIS_DATA_DIR}/nodes.conf")
+                nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP:/g" "${REDIS_DATA_DIR}/nodes.conf")
                 echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
             fi
             host_2_ip_array["$node"]="$newIP"

--- a/6.2/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
+++ b/6.2/debian-10/rootfs/opt/bitnami/scripts/librediscluster.sh
@@ -203,7 +203,7 @@ redis_cluster_update_ips() {
             # The node can be new if we are updating the cluster, so catch the unbound variable error
             if [[ ${host_2_ip_array[$node]+true} ]]; then
                 echo "Changing old IP ${host_2_ip_array[$node]} by the new one ${newIP}"
-                nodesFile=$(sed "s/${host_2_ip_array[$node]}/$newIP/g" "${REDIS_DATA_DIR}/nodes.conf")
+                nodesFile=$(sed "s/ ${host_2_ip_array[$node]}:/ $newIP:/g" "${REDIS_DATA_DIR}/nodes.conf")
                 echo "$nodesFile" >"${REDIS_DATA_DIR}/nodes.conf"
             fi
             host_2_ip_array["$node"]="$newIP"


### PR DESCRIPTION
**Description of the change**
Currently if nodes.conf contains multiple IP addresseswith same prefix/suffix  (e.g. 10.0.0.2 , 10.0.0.22, 10.0.0.222 and 110.0.0.2) then regex logic will match to them all which leads to broken nodes.conf:
```
$ cat nodes.conf
a7d6e6cdb512a5fbd6dff64afbbb516c204caaff 10.0.0.2:6379@16379 myself,slave d12b5d035ce2bad9e5925c7051d24df0d3b91374 0 1627628983000 54 connected
0eb7ec5882884658e161b7f8c2980c776e8f9968 10.0.0.22:6379@16379 master,fail? - 1627628704697 1627628704697 47 disconnected 0-5460
8704f3ca30a99401eda4fc401716584777008f2b 10.0.0.222:6379@16379 slave,fail? 0eb7ec5882884658e161b7f8c2980c776e8f9968 1627628704697 1627628704697 47 disconnected
d12b5d035ce2bad9e5925c7051d24df0d3b91374 110.0.0.2:6379@16379 master,fail? - 1627628704697 1627628704697 55 disconnected 10923-16383

$ sed "s/10.0.0.2/x.x.x.x/g" nodes.conf
a7d6e6cdb512a5fbd6dff64afbbb516c204caaff x.x.x.x:6379@16379 myself,slave d12b5d035ce2bad9e5925c7051d24df0d3b91374 0 1627628983000 54 connected
0eb7ec5882884658e161b7f8c2980c776e8f9968 x.x.x.x2:6379@16379 master,fail? - 1627628704697 1627628704697 47 disconnected 0-5460
8704f3ca30a99401eda4fc401716584777008f2b x.x.x.x22:6379@16379 slave,fail? 0eb7ec5882884658e161b7f8c2980c776e8f9968 1627628704697 1627628704697 47 disconnected
d12b5d035ce2bad9e5925c7051d24df0d3b91374 1x.x.x.x:6379@16379 master,fail? - 1627628704697 1627628704697 55 disconnected 10923-16383
```

That why we have to match string `<space><IP><colon>` which is actual nodes.conf format:
```
$ sed "s/ 10.0.0.2:/ x.x.x.x:/g" nodes.conf
a7d6e6cdb512a5fbd6dff64afbbb516c204caaff x.x.x.x:6379@16379 myself,slave d12b5d035ce2bad9e5925c7051d24df0d3b91374 0 1627628983000 54 connected
0eb7ec5882884658e161b7f8c2980c776e8f9968 10.0.0.22:6379@16379 master,fail? - 1627628704697 1627628704697 47 disconnected 0-5460
8704f3ca30a99401eda4fc401716584777008f2b 10.0.0.222:6379@16379 slave,fail? 0eb7ec5882884658e161b7f8c2980c776e8f9968 1627628704697 1627628704697 47 disconnected
d12b5d035ce2bad9e5925c7051d24df0d3b91374 110.0.0.2:6379@16379 master,fail? - 1627628704697 1627628704697 55 disconnected 10923-16383
```

**Benefits**
Fixes bug on current implementation.

**Possible drawbacks**

No

**Applicable issues**

**Additional information**


